### PR TITLE
Remove init_attributes() function from BFS

### DIFF
--- a/src/traversals/bfs.c
+++ b/src/traversals/bfs.c
@@ -1,15 +1,5 @@
 #include "bfs.h"
 
-/* Function to initialise the attributes of each node */
-void init_attributes(struct attributes *nodes, int n) {
-	int i;
-	for (i = 1; i <= n; i++) {
-		nodes[i].parent = NIL;
-		nodes[i].distance = INF;
-		nodes[i].current_color = WHITE;
-	}
-}
-
 /* Function to print the value of attributes */
 void print_attributes(struct attributes *nodes, int n) {
 	int i;
@@ -18,21 +8,20 @@ void print_attributes(struct attributes *nodes, int n) {
 		printf("%4d : %6d\t%7d\n", i, nodes[i].parent, nodes[i].distance);
 }
 
-/* Function to implement BFS on a graph 
+/* Function to implement BFS on a graph
  * TODO: Replace `nodes` with a more appropriate name
  */
 void bfs(struct Graph *graph, struct attributes *nodes, int source) {
 	int i;
 	struct Queue *Q;
-	init_attributes(nodes, graph->V);
 	to_list(graph);
 	Q = init_queue(Q);
-	
+
 	nodes[source].current_color = GRAY;
 	nodes[source].distance = 0;
 	enqueue(Q, source);
-	
-	while (Q->first != NULL && Q->last != NULL) {	
+
+	while (Q->first != NULL && Q->last != NULL) {
 		int current_node = dequeue(Q);
 		struct node *iter = (graph->list[current_node]).head;
 		while (iter != NULL) {
@@ -45,6 +34,6 @@ void bfs(struct Graph *graph, struct attributes *nodes, int source) {
 			}
 			iter = iter->next;
 		}
-		nodes[current_node].current_color = BLACK;  	
+		nodes[current_node].current_color = BLACK;
 	}
 }


### PR DESCRIPTION
A BFS need not to initialize the nodes each time it is run

It totally negates the usage of bfs for checking connectedness.
