### PR TITLE
Fix function prototypes

### DIFF
--- a/src/ADTs/queue.h
+++ b/src/ADTs/queue.h
@@ -9,11 +9,11 @@
  *
  *	Operations :
  *		Use `INIT_QUEUE()` to initialize the queue.
- *		Use `ENQUEUE()` and `DEQUEUE()` functions for operations on 
+ *		Use `ENQUEUE()` and `DEQUEUE()` functions for operations on
  * 		the queue.
  *		Use `PRINT_QUEUE()` to print out the Queue.
  *
- *	Example :	
+ *	Example :
  *		```
  *		#include "queue.h"
  *
@@ -50,7 +50,7 @@ struct Queue {
 };
 
 /* Create empty Queue */
-struct Queue *init_queue();
+struct Queue *init_queue(void);
 
 /* Function to remove an element from Queue and return the node */
 int dequeue(struct Queue *);

--- a/src/ADTs/stack.h
+++ b/src/ADTs/stack.h
@@ -24,7 +24,7 @@
  *			PRINT_STACK(S);
  *		}
  *		```
- *		Output : 
+ *		Output :
  *			2 <- 1
  */
 
@@ -47,7 +47,7 @@ struct Stack{
 };
 
 /* Function to create an empty Stack */
-struct Stack* INIT_STACK();
+struct Stack* INIT_STACK(void);
 
 /* Function to add an element to the Stack */
 void PUSH(struct Stack*, int);
@@ -59,4 +59,5 @@ int POP(struct Stack*);
 void PRINT_STACK(struct Stack*);
 
 #endif
+
 


### PR DESCRIPTION
Use `void` for no arguments.
